### PR TITLE
商品一覧表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @item = Item.all
+    @items = Item.order("id DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,27 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
       
-      <% @item.each do |item| %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
          <%= image_tag item.image, class: "item-img" %>
-         <% end %>
+        <% end %>
           <%# 商品が売れていればsold outを表示しましょう %>
           <div class='sold-out'>
-            <span>Sold Out!!</span>
+            <%# if item.buyer_id.present? %>
+            <!--<span>Sold Out!!</span>-->
+            <%# end %>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
+            <span><%= item.price %>円<br>(税込み)</span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,7 +155,6 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>


### PR DESCRIPTION
What  商品一覧表示について（Sold Out機能は除く）
Why　メンターさんに確認していただき、次の実装に進むため

売却済みの商品は、画像上に「sold out」の文字が表示されるようになっていることについてはトレロの補足情報にあったように商品購入機能実装後に実装することにするためここではSold Outの文字をコメントアウトし実装していません！


https://i.gyazo.com/c34762458e1499830803dadc3bcb3360.mp4
ログアウト状態のユーザーでも、商品一覧表示ページを見ることができること

https://i.gyazo.com/73d6199eae6d99ec68dda1a135f55780.mp4
上から、出品された日時が新しい順に表示されること
画像/価格/商品名の3つの情報について表示できていること